### PR TITLE
Minor UI fix, dead links

### DIFF
--- a/TEDxHQ/css/style.css
+++ b/TEDxHQ/css/style.css
@@ -1954,7 +1954,6 @@ h4,
     border: none;
     width: 100%;
     white-space: nowrap;
-    overflow: hidden;
     -webkit-animation: typing 3s steps(31, end),
         blink-caret .5s step-end infinite alternate;
 }

--- a/TEDxHQ/index.html
+++ b/TEDxHQ/index.html
@@ -4,7 +4,7 @@
 
     <meta charset="utf-8">
     <!--
-    Email us! contact@0x48piraj.co ♥
+        Email us! contact@0x48piraj.co ♥
     -->
     <title>TEDxP Digital ♥ Coding worth Spreading!</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -38,8 +38,8 @@
 
     <!-- THE TWITTER MACHINE -->
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:site" content="@TEDxP">
-    <meta name="twitter:creator" content="@TEDxP">
+    <meta name="twitter:site" content="@_tedxpTeam">
+    <meta name="twitter:creator" content="@_tedxpTeam">
     <meta name="twitter:title" content="TEDxP Digital">
     <meta name="twitter:description" content="Coding worth Spreading!">
     <meta name="twitter:image:src" content="img/share.jpg">
@@ -124,7 +124,7 @@
                     <div class="icon"><a href="https://facebook.com/TED/"><img src="img/fb.png" class="center-block" /></a></div>
                 </section>
                 <section class="col-xs-3 col-sm-3 col-md-3 col-lg-3">
-                    <div class="icon"><a href="https://twitter.com/_tedxp"><img src="img/twitter.png" class="center-block" /></a></div>
+                    <div class="icon"><a href="https://twitter.com/_tedxpTeam"><img src="img/twitter.png" class="center-block" /></a></div>
                 </section>
             </div>
         </div>
@@ -293,13 +293,13 @@
                 </div>
                 <div class="col-md-8 copyright clearfix">
                     <span class="icons">
-                        <a target="_blank" href="http://TEDxP/">Our Blog</a>
+                        <a target="_blank">Our Blog</a>     <!-- href="http://TEDxP/" -->
                         <span class="separator"><i class="ti-heart"></i></span>
                         <a target="_blank" href="https://leanpub.com/mean-machine">Mean Machine</a>
                         <span class="separator"><i class="ti-heart"></i></span>
-                        <a target="_blank" href="https://box.TEDxP/">Box</a>
+                        <a target="_blank">Box</a>          <!-- href="https://box.TEDxP/"-->
                         <span class="separator"><i class="ti-heart"></i></span>
-                        <a target="_blank" href="https://panels.TEDxP/">Panels</a>
+                        <a target="_blank">Panels</a>       <!-- href="https://panels.TEDxP/"-->
                         <span class="separator"><i class="ti-heart"></i></span>
                         <a target="_blank" href="https://twitter.com/_tedxp"><i class="ti-twitter-alt"></i></a>
                         <a target="_blank" href="https://facebook.com/TED"><i class="ti-facebook"></i></a>

--- a/TEDxHQ/index.html
+++ b/TEDxHQ/index.html
@@ -293,13 +293,13 @@
                 </div>
                 <div class="col-md-8 copyright clearfix">
                     <span class="icons">
-                        <a target="_blank">Our Blog</a>     <!-- href="http://TEDxP/" -->
+                        <a href="#">Our Blog</a>     <!-- href="http://TEDxP/" -->
                         <span class="separator"><i class="ti-heart"></i></span>
                         <a target="_blank" href="https://leanpub.com/mean-machine">Mean Machine</a>
                         <span class="separator"><i class="ti-heart"></i></span>
-                        <a target="_blank">Box</a>          <!-- href="https://box.TEDxP/"-->
+                        <a href="#">Box</a>          <!-- href="https://box.TEDxP/"-->
                         <span class="separator"><i class="ti-heart"></i></span>
-                        <a target="_blank">Panels</a>       <!-- href="https://panels.TEDxP/"-->
+                        <a href="#">Panels</a>       <!-- href="https://panels.TEDxP/"-->
                         <span class="separator"><i class="ti-heart"></i></span>
                         <a target="_blank" href="https://twitter.com/_tedxp"><i class="ti-twitter-alt"></i></a>
                         <a target="_blank" href="https://facebook.com/TED"><i class="ti-facebook"></i></a>


### PR DESCRIPTION

<img width="434" alt="tedxP" src="https://user-images.githubusercontent.com/37269665/94726007-43018a80-037a-11eb-8341-6975e88522d2.png">

Removed target="_blank" and href="" for dead links to href="#"
Updated twitter profile URL

Updated css for `.codeblock` to allow the tagline to completely display
I encountered this problem on Firefox on a 14 inch 1920x1080 screen, can't say why.

* Till i know, though there could be atleast two ways to correct it: i did by allowing overflow, other could have been width:110%

https://github.com/TEDxP/explore_WEB_TEMPLATES/blob/33b6ea1e67cfff24f3aff2aa6a55c1d2562c4eaf/TEDxHQ/css/style.css#L1955

https://github.com/TEDxP/explore_WEB_TEMPLATES/blob/33b6ea1e67cfff24f3aff2aa6a55c1d2562c4eaf/TEDxHQ/css/style.css#L1957

Addresses #23 also
